### PR TITLE
Add simple heroku setup

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: node index.js

--- a/README.md
+++ b/README.md
@@ -17,13 +17,21 @@ As well as providing a place for people to hone their code skills, it also provi
 
 ## Contributing
 
-## Ideas
+### Ideas
 
 - Open an issue using the proposal/idea label
 
-## Code
+### Code
 
 - Create a branch from master
 - Code
 - Open PR with description and example of feature
 - Do not merge to master directly.
+
+## Deploying
+
+```
+git checkout master
+git pull origin master
+git push heroku master
+```

--- a/app.json
+++ b/app.json
@@ -1,0 +1,7 @@
+{
+  "name": "Fenders Bot",
+  "description": "A group project for learning and teaching via a real code base.",
+  "repository": "https://github.com/fendersperth/fendersbot",
+  "keywords": ["node", "express", "slack"],
+  "image": "heroku/nodejs"
+}

--- a/index.js
+++ b/index.js
@@ -12,5 +12,5 @@ let app = express();
 app.set('port', process.env.PORT || 5000);
 app.get('/', function(req, res) { res.send('hello world'); })
 app.listen(app.get('port'), function () {
-  console.log('App listening on port', app.get('port'))
+  console.log('Application is running on port ' + app.get('port'));
 })

--- a/package.json
+++ b/package.json
@@ -2,11 +2,24 @@
   "name": "fendersbot",
   "version": "0.1.0",
   "private": true,
+  "description": "A group project for learning and teaching via a real code base.",
+  "main": "index.js",
   "scripts": {
-    "start": "node index.js"
+    "start": "node index.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/fendersperth/fendersbot.git"
+  },
+  "author": "https://fendersslack.herokuapp.com/",
+  "homepage": "https://github.com/fendersperth/fendersbot",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/fendersperth/fendersbot/issues"
   },
   "dependencies": {
-    "express": "~4.13.1",
+    "express": "~4.13.3",
     "slack-client": "^1.4.1"
   }
 }


### PR DESCRIPTION
This adds some simple Heroku configuration and setup to allow us to deploy to `http://fendersbot.herokuapp.com`. Although this may change, this is a simple solution for something we need sooner rather than later.

```
Counting objects: 9, done.
Delta compression using up to 4 threads.
Compressing objects: 100% (8/8), done.
Writing objects: 100% (9/9), 1.46 KiB | 0 bytes/s, done.
Total 9 (delta 3), reused 0 (delta 0)
remote: Compressing source files... done.
remote: Building source:
remote:
remote: -----> Using set buildpack heroku/nodejs
remote: -----> Node.js app detected
remote:
remote: -----> Creating runtime environment
remote:
remote:        NPM_CONFIG_LOGLEVEL=error
remote:        NPM_CONFIG_PRODUCTION=true
remote:        NODE_ENV=production
remote:        NODE_MODULES_CACHE=true
remote:
remote: -----> Installing binaries
remote:        engines.node (package.json):  unspecified
remote:        engines.npm (package.json):   unspecified (use default)
remote:
remote:        Resolving node version (latest stable) via semver.io...
remote:        Downloading and installing node 5.0.0...
remote:        Using default npm version: 3.3.6
remote:
remote: -----> Restoring cache
remote:        Loading 2 from cacheDirectories (default):
remote:        - node_modules
remote:        - bower_components (not cached - skipping)
remote:
remote: -----> Building dependencies
remote:        Pruning any extraneous modules
remote:        Installing node modules (package.json)
remote:
remote:        > ws@0.4.31 install /tmp/build_6743bca8e3c2a254bfb4c2a248673bb9/node_modules/ws
remote:        > (node-gyp rebuild 2> builderror.log) || (exit 0)
remote:
remote:        make: Entering directory `/tmp/build_6743bca8e3c2a254bfb4c2a248673bb9/node_modules/ws/build'
remote:        CXX(target) Release/obj.target/bufferutil/src/bufferutil.o
remote:        make: Leaving directory `/tmp/build_6743bca8e3c2a254bfb4c2a248673bb9/node_modules/ws/build'
remote:
remote: -----> Caching build
remote:        Clearing previous node cache
remote:        Saving 2 cacheDirectories (default):
remote:        - node_modules
remote:        - bower_components (nothing to cache)
remote:
remote: -----> Build succeeded!
remote:        ├── express@4.13.3
remote:        └── slack-client@1.4.1
remote:
remote:
remote: -----> Discovering process types
remote:        Procfile declares types -> web
remote:
remote: -----> Compressing... done, 11.8MB
remote: -----> Launching... done, v5
remote:        https://fendersbot.herokuapp.com/ deployed to Heroku
remote:
remote: Verifying deploy.... done.
To https://git.heroku.com/fendersbot.git
 + 74decd7...50763f8 heroku -> master (forced update)
```
